### PR TITLE
Gold income changes

### DIFF
--- a/core/src/bunzosteele/heroesemblem/model/ShopState.java
+++ b/core/src/bunzosteele/heroesemblem/model/ShopState.java
@@ -37,7 +37,7 @@ public class ShopState
 		this.roster = battleState.roster;
 		this.stock = UnitGenerator.GenerateStock(this.roster, battleState.game);
 		this.selected = null;
-		int bonusGold = 300 + battleState.difficulty * 25;
+		int bonusGold = 500 + battleState.difficulty * 15;
 		int totalLevel = 0;
 		for(Unit unit : roster){
 			totalLevel+= unit.level;


### PR DESCRIPTION
Increases the starting income to 500
Reduces the difficulty multiplier to difficulty lvl X 15 from difficulty lvl X 25
This should help with the early game money difficulty, yet prevent end game money snowballing.
